### PR TITLE
Update etcd path test to always use kindWhiteList

### DIFF
--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -420,7 +420,7 @@ var ephemeralWhiteList = createEphemeralWhiteList(
 	// --
 )
 
-// Only add kinds to this list when there is no mapping from GVK to GVR (and thus there is no way to create the object)
+// Only add kinds to this list when there is no way to create the object
 var kindWhiteList = sets.NewString(
 	// k8s.io/kubernetes/pkg/api/v1
 	"DeleteOptions",
@@ -478,14 +478,14 @@ func TestEtcdStoragePath(t *testing.T) {
 		kind := gvk.Kind
 		pkgPath := apiType.PkgPath()
 
+		if kindWhiteList.Has(kind) {
+			kindSeen.Insert(kind)
+			continue
+		}
+
 		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
-			kindSeen.Insert(kind)
-			if kindWhiteList.Has(kind) {
-				// t.Logf("skipping test for %s from %s because its GVK %s is whitelisted and has no mapping", kind, pkgPath, gvk)
-			} else {
-				t.Errorf("no mapping found for %s from %s but its GVK %s is not whitelisted", kind, pkgPath, gvk)
-			}
+			t.Errorf("unexpected error getting mapping for %s from %s with GVK %s: %v", kind, pkgPath, gvk, err)
 			continue
 		}
 


### PR DESCRIPTION
Most types now have valid rest mappings because
NewDefaultRESTMapperFromScheme no longer ignores certain import
paths.  Thus we can no longer use the lack of a valid REST mapping
as an indicator for when to use kindWhiteList.  Thus kindWhiteList
now serves as a whitelist for all kinds and not just those that
formally had no mapping.  This does mean that we could whitelist
kinds due to a name conflict, but that is unlikely as names such as
GetOptions are not appropriate for new objects.

Signed-off-by: Monis Khan <mkhan@redhat.com>